### PR TITLE
remove process.exit(1) on child.on('stderr')

### DIFF
--- a/gulp-forever-monitor.js
+++ b/gulp-forever-monitor.js
@@ -32,8 +32,7 @@ module.exports = function (source, options) {
         
     child.on('stderr', function(err) {
         console.log(err.toString());
-        process.exit(1);  
-    }) 
+    });
     
     process.on('SIGINT', function() {
         process.exit(); 
@@ -41,7 +40,7 @@ module.exports = function (source, options) {
         
     process.on('SIGTERM', function() {
         process.exit(); 
-    }); 
+    });
     
     process.on('exit', function() { 
         child.stop();      


### PR DESCRIPTION
Allows using forever monitor to run continuously even after syntax errors for a continuous build/run environment for development

I also made `;` consistent :)
