### PR TITLE
Remove stderr logging

### DIFF
--- a/gulp-forever-monitor.js
+++ b/gulp-forever-monitor.js
@@ -30,10 +30,6 @@ module.exports = function (source, options) {
     
     child = new (forever.Monitor)(source, options);
         
-    child.on('stderr', function(err) {
-        console.log(err.toString());
-    });
-    
     process.on('SIGINT', function() {
         process.exit(); 
     });


### PR DESCRIPTION
This fixes it from double logging errors to the console if the child process is using `console.error(…)`
